### PR TITLE
🩹 fix : swagger 401 에러 수정 및 토큰 인증 적용

### DIFF
--- a/blink/settings.py
+++ b/blink/settings.py
@@ -232,3 +232,17 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+# Swagger Setting
+SWAGGER_SETTINGS = {
+    'SECURITY_DEFINITIONS': {
+        'Bearer': {
+            'type': 'apiKey',
+            'name': 'Authorization',
+            'in': 'header'
+        }
+    }
+}
+
+LOGIN_URL = '/api/v1/user/kakao/login'
+LOGOUT_URL = '/api/v1/user/logout'

--- a/blink/urls.py
+++ b/blink/urls.py
@@ -13,7 +13,9 @@ Class-based views
 Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+    
 """
+from rest_framework import permissions
 from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
@@ -33,6 +35,7 @@ schema_view = get_schema_view(
         license=openapi.License(name="BSD License"),
     ),
     public=True,
+    permission_classes=(permissions.AllowAny,)
 )
 
 urlpatterns = [


### PR DESCRIPTION
- swagger api 요청시 401 에러 나는거 수정했습니다.
- django login 버튼과 Authorize 버튼 토큰 기반으로 변경했습니다.
- swagger UI에서 django login 버튼을 누를 시 카카오 로그인으로 연결되게 해두었습니다.